### PR TITLE
Add option to install a local package to be deployed as well

### DIFF
--- a/aws_lambda/aws_lambda.py
+++ b/aws_lambda/aws_lambda.py
@@ -18,12 +18,15 @@ from .helpers import mkdir, read, archive, timestamp
 log = logging.getLogger(__name__)
 
 
-def deploy(src):
+def deploy(src, local_package=None):
     """Deploys a new function to AWS Lambda.
 
     :param str src:
         The path to your Lambda ready project (folder must contain a valid
         config.yaml and handler module (e.g.: service.py).
+    :param str local_package:
+        The path to a local package with should be included in the deploy as
+        well (and/or is not available on PyPi)
     """
     # Load and parse the config file.
     path_to_config_file = os.path.join(src, 'config.yaml')
@@ -33,7 +36,7 @@ def deploy(src):
     # folder then add the handler file in the root of this directory.
     # Zip the contents of this folder into a single file and output to the dist
     # directory.
-    path_to_zip_file = build(src)
+    path_to_zip_file = build(src, local_package)
 
     if function_exists(cfg, cfg.get('function_name')):
         update_function(cfg, path_to_zip_file)
@@ -101,15 +104,15 @@ def init(src, minimal=False):
         copy(path_to_file, src)
 
 
-def build(src):
+def build(src, local_package=None):
     """Builds the file bundle.
 
-    :param str path_to_handler_file:
-       The path to handler (main execution) file.
-    :param str path_to_dist:
-       The path to the folder for distributable.
-    :param str output_filename:
-       The name of the archive file.
+    :param str src:
+       The path to your Lambda ready project (folder must contain a valid
+        config.yaml and handler module (e.g.: service.py).
+    :param str local_package:
+        The path to a local package with should be included in the deploy as
+        well (and/or is not available on PyPi)
     """
     # Load and parse the config file.
     path_to_config_file = os.path.join(src, 'config.yaml')
@@ -127,7 +130,7 @@ def build(src):
     output_filename = "{0}-{1}.zip".format(timestamp(), function_name)
 
     path_to_temp = mkdtemp(prefix='aws-lambda')
-    pip_install_to_target(path_to_temp)
+    pip_install_to_target(path_to_temp, local_package)
 
     # Gracefully handle whether ".zip" was included in the filename or not.
     output_filename = ('{0}.zip'.format(output_filename)
@@ -188,19 +191,25 @@ def get_handler_filename(handler):
     return '{0}.py'.format(module_name)
 
 
-def pip_install_to_target(path):
+def pip_install_to_target(path, local_package=None):
     """For a given active virtualenv, gather all installed pip packages then
     copy (re-install) them to the path provided.
 
     :param str path:
         Path to copy installed pip packages to.
+    :param str local_package:
+        The path to a local package with should be included in the deploy as
+        well (and/or is not available on PyPi)
     """
     print('Gathering pip packages')
     for r in pip.operations.freeze.freeze():
-        if r.startswith('Python=='):
+        if r.startswith('Python==') or r.startswith('-e git+git'):
             # For some reason Python is coming up in pip freeze.
             continue
         pip.main(['install', r, '-t', path, '--ignore-installed'])
+
+    if local_package is not None:
+        pip.main(['install', local_package, '-t', path])
 
 
 def get_role_name(account_id, role):

--- a/scripts/lambda
+++ b/scripts/lambda
@@ -21,8 +21,9 @@ def init():
 
 
 @click.command(help="Bundles package for deployment.")
-def build():
-    aws_lambda.build(CURRENT_DIR)
+@click.option('--local-package', default=None, help='Install local package as well.', type=click.Path())
+def build(local_package):
+    aws_lambda.build(CURRENT_DIR, local_package)
 
 
 @click.command(help="Run a local test of your function.")
@@ -33,8 +34,9 @@ def invoke(event_file, verbose):
 
 
 @click.command(help="Register and deploy your code to lambda.")
-def deploy():
-    aws_lambda.deploy(CURRENT_DIR)
+@click.option('--local-package', default=None, help='Install local package as well.', type=click.Path())
+def deploy(local_package):
+    aws_lambda.deploy(CURRENT_DIR, local_package)
 
 if __name__ == '__main__':
     cli.add_command(init)


### PR DESCRIPTION
If you want to deploy your lambda function and need a dependency which
is not available on PyPi, but only to your local machine (private package, ...)
you can now add this to the dist archive as well.

For both, the `build` and `deploy` option, an optional argument `--local-package`
can be provided with the path to the package you want to install via pip.
Your package needs to have a `setup.py` file.

Example:
    $ lambda build --local-package .