### PR TITLE
Update function configuration after deploy

### DIFF
--- a/aws_lambda/__init__.py
+++ b/aws_lambda/__init__.py
@@ -2,7 +2,7 @@
 # flake8: noqa
 __author__ = 'Nick Ficano'
 __email__ = 'nficano@gmail.com'
-__version__ = '0.1.11'
+__version__ = '0.2.1'
 
 from .aws_lambda import deploy, invoke, init, build
 

--- a/aws_lambda/aws_lambda.py
+++ b/aws_lambda/aws_lambda.py
@@ -273,6 +273,9 @@ def update_function(cfg, path_to_zip_file):
     aws_access_key_id = cfg.get('aws_access_key_id')
     aws_secret_access_key = cfg.get('aws_secret_access_key')
 
+    account_id = get_account_id(aws_access_key_id, aws_secret_access_key)
+    role = get_role_name(account_id, cfg.get('role', 'lambda_basic_execution'))
+
     client = get_client('lambda', aws_access_key_id, aws_secret_access_key,
                         cfg.get('region'))
 
@@ -280,6 +283,15 @@ def update_function(cfg, path_to_zip_file):
         FunctionName=cfg.get('function_name'),
         ZipFile=byte_stream,
         Publish=True
+    )
+
+    client.update_function_configuration(
+        FunctionName=cfg.get('function_name'),
+        Role=role,
+        Handler=cfg.get('handler'),
+        Description=cfg.get('description'),
+        Timeout=cfg.get('timeout', 15),
+        MemorySize=cfg.get('memory_size', 512)
     )
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,11 @@
-boto3==1.3.0
-botocore==1.4.7
-click==6.4
+boto3==1.3.1
+botocore==1.4.32
+click==6.6
 docutils==0.12
 futures==3.0.5
 jmespath==0.9.0
 pyaml==15.8.2
-python-dateutil==2.5.1
+python-dateutil==2.5.3
+python-lambda==0.2.0
 PyYAML==3.11
 six==1.10.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.11
+current_version = 0.2.1
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ test_requirements = [
 
 setup(
     name='python-lambda',
-    version='0.1.11',
+    version='0.2.1',
     description="The bare minimum for a Python app running on Amazon Lambda.",
     long_description=readme + '\n\n' + history,
     author="Nick Ficano",


### PR DESCRIPTION
Each time a change is made in the `config.yaml` and `lambda deploy` is
invoked, the changed parameters were not updated for the new version.

This commit changes the default behaviour to also update the function
configuration with each deploy.