### PR TITLE
Requirements only

### DIFF
--- a/aws_lambda/aws_lambda.py
+++ b/aws_lambda/aws_lambda.py
@@ -18,7 +18,7 @@ from .helpers import mkdir, read, archive, timestamp
 log = logging.getLogger(__name__)
 
 
-def deploy(src, local_package=None):
+def deploy(src, requirements=False, local_package=None):
     """Deploys a new function to AWS Lambda.
 
     :param str src:
@@ -36,7 +36,7 @@ def deploy(src, local_package=None):
     # folder then add the handler file in the root of this directory.
     # Zip the contents of this folder into a single file and output to the dist
     # directory.
-    path_to_zip_file = build(src, local_package)
+    path_to_zip_file = build(src, requirements, local_package)
 
     if function_exists(cfg, cfg.get('function_name')):
         update_function(cfg, path_to_zip_file)
@@ -104,7 +104,7 @@ def init(src, minimal=False):
         copy(path_to_file, src)
 
 
-def build(src, local_package=None):
+def build(src, requirements=False, local_package=None):
     """Builds the file bundle.
 
     :param str src:
@@ -130,7 +130,9 @@ def build(src, local_package=None):
     output_filename = "{0}-{1}.zip".format(timestamp(), function_name)
 
     path_to_temp = mkdtemp(prefix='aws-lambda')
-    pip_install_to_target(path_to_temp, local_package)
+    pip_install_to_target(path_to_temp,
+                          requirements=requirements,
+                          local_package=local_package)
 
     # Gracefully handle whether ".zip" was included in the filename or not.
     output_filename = ('{0}.zip'.format(output_filename)
@@ -191,29 +193,61 @@ def get_handler_filename(handler):
     return '{0}.py'.format(module_name)
 
 
-def pip_install_to_target(path, local_package=None):
+def _install_packages(path, packages):
+    """Install all packages listed to the target directory.
+
+    Ignores any package that includes Python itself and python-lambda as well
+    since its only needed for deploying and not running the code
+
+    :param str path:
+        Path to copy installed pip packages to.
+    :param list packages:
+        A list of packages to be installed via pip.
+    """
+    def _filter_blacklist(package):
+        blacklist = ["-i", "#", "Python==", "python-lambda=="]
+        return all(package.startswith(entry) is False for entry in blacklist)
+    filtered_packages = filter(_filter_blacklist, packages)
+    for package in filtered_packages:
+        if package.startswith('-e '):
+            package = package.replace('-e ', '')
+
+        print('Installing {package}'.format(package=package))
+        pip.main(['install', package, '-t', path, '--ignore-installed'])
+
+
+def pip_install_to_target(path, requirements=False, local_package=None):
     """For a given active virtualenv, gather all installed pip packages then
     copy (re-install) them to the path provided.
 
     :param str path:
         Path to copy installed pip packages to.
+    :param bool requirements:
+        If set, only the packages in the requirements.txt file are installed.
+        The requirements.txt file needs to be in the same directory as the
+        project which shall be deployed.
+        Defaults to false and installs all pacakges found via pip freeze if
+        not set.
     :param str local_package:
         The path to a local package with should be included in the deploy as
         well (and/or is not available on PyPi)
     """
-    print('Gathering pip packages')
-    for r in pip.operations.freeze.freeze():
-        if r.startswith('Python=='):
-            # For some reason Python is coming up in pip freeze.
-            continue
-        elif r.startswith('-e '):
-            r = r.replace('-e ','')
+    packages = []
+    if not requirements:
+        print('Gathering pip packages')
+        packages.extend(pip.operations.freeze.freeze())
+    else:
+        if os.path.exists("requirements.txt"):
+            print('Gathering requirement packages')
+            data = read("requirements.txt")
+            packages.extend(data.splitlines())
 
-        print('Installing {package}'.format(package=r))
-        pip.main(['install', r, '-t', path, '--ignore-installed'])
+    if not packages:
+        print('No dependency packages installed!')
 
     if local_package is not None:
-        pip.main(['install', local_package, '-t', path])
+        packages.append(local_package)
+    _install_packages(path, packages)
 
 
 def get_role_name(account_id, role):

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,5 @@ futures==3.0.5
 jmespath==0.9.0
 pyaml==15.8.2
 python-dateutil==2.5.3
-python-lambda==0.2.0
 PyYAML==3.11
 six==1.10.0

--- a/scripts/lambda
+++ b/scripts/lambda
@@ -21,9 +21,10 @@ def init():
 
 
 @click.command(help="Bundles package for deployment.")
+@click.option('--use-requirements', default=False, is_flag=True, help='Install all packages defined in requirements.txt')
 @click.option('--local-package', default=None, help='Install local package as well.', type=click.Path())
-def build(local_package):
-    aws_lambda.build(CURRENT_DIR, local_package)
+def build(use_requirements, local_package):
+    aws_lambda.build(CURRENT_DIR, use_requirements, local_package)
 
 
 @click.command(help="Run a local test of your function.")
@@ -34,9 +35,11 @@ def invoke(event_file, verbose):
 
 
 @click.command(help="Register and deploy your code to lambda.")
+@click.option('--use-requirements', default=False, is_flag=True, help='Install all packages defined in requirements.txt')
 @click.option('--local-package', default=None, help='Install local package as well.', type=click.Path())
-def deploy(local_package):
-    aws_lambda.deploy(CURRENT_DIR, local_package)
+def deploy(use_requirements, local_package):
+    aws_lambda.deploy(CURRENT_DIR, use_requirements, local_package)
+
 
 if __name__ == '__main__':
     cli.add_command(init)


### PR DESCRIPTION
Install only required packages if option is set

The current solution installs all packages found by pip freeze to the
distribution folder and deploys this to AWS Lambda.
This includes some unnecessary packages to run the code, e.g. testing modules
which increase the distribution size.

The option to install only required packages helps reducing the build size.
For now, the file must be named `requirements.txt` and be in the same
directory of the project which shall be uploaded.

A new optional flag is added to the CLI and the package itself (`python-lambda`) is removed from the 
requirements file of this project. It shouldn't install itself.
