### PR TITLE
lambda init accepts optional folder name

### DIFF
--- a/scripts/lambda
+++ b/scripts/lambda
@@ -16,8 +16,16 @@ def cli():
 
 
 @click.command(help="Create a new function for Lambda.")
-def init():
-    aws_lambda.init(CURRENT_DIR)
+@click.argument('folder', default=False)
+def init(folder):
+    path = CURRENT_DIR
+    if folder:
+        path = "{}/{}".format(CURRENT_DIR, folder)
+        if os.path.isfile(path):
+            raise click.ClickException("{} is a file".format(path))
+        if not os.path.exists(path):
+            os.makedirs(path)
+    aws_lambda.init(path)
 
 
 @click.command(help="Bundles package for deployment.")

--- a/scripts/lambda
+++ b/scripts/lambda
@@ -16,13 +16,11 @@ def cli():
 
 
 @click.command(help="Create a new function for Lambda.")
-@click.argument('folder', default=False)
+@click.argument('folder', nargs=-1, type=click.Path(file_okay=False, writable=True))
 def init(folder):
     path = CURRENT_DIR
-    if folder:
-        path = "{}/{}".format(CURRENT_DIR, folder)
-        if os.path.isfile(path):
-            raise click.ClickException("{} is a file".format(path))
+    if len(folder) > 0:
+        path = "{}/{}".format(CURRENT_DIR, folder[0])
         if not os.path.exists(path):
             os.makedirs(path)
     aws_lambda.init(path)


### PR DESCRIPTION
`lambda init` now takes an optional folder name.

eg: `lambda init example_lambda`
- Creates the folder if it doesn't exist
- Sample files are created in the folder if it exits
- If the name provided is a file, throws an exception.
