### PR TITLE
add keyword arg for VpcConfig on lambda function update

### DIFF
--- a/aws_lambda/aws_lambda.py
+++ b/aws_lambda/aws_lambda.py
@@ -303,6 +303,13 @@ def create_function(cfg, path_to_zip_file):
         Description=cfg.get('description'),
         Timeout=cfg.get('timeout', 15),
         MemorySize=cfg.get('memory_size', 512),
+        Environment={
+            'Variables': {
+                key.strip('LAMBDA_'): value
+                for key, value in os.envinron.items()
+                if key.startswith('LAMBDA_')
+            }
+        },
         Publish=True
     )
 

--- a/aws_lambda/aws_lambda.py
+++ b/aws_lambda/aws_lambda.py
@@ -294,8 +294,10 @@ def create_function(cfg, path_to_zip_file):
     client = get_client('lambda', aws_access_key_id, aws_secret_access_key,
                         cfg.get('region'))
 
+    function_name = os.environ.get('LAMBDA_FUNCTION_NAME') or cfg.get('function_name')
+    print('Creating lambda function with name: {}'.format(function_name))
     client.create_function(
-        FunctionName=cfg.get('function_name'),
+        FunctionName=function_name,
         Runtime=cfg.get('runtime', 'python2.7'),
         Role=role,
         Handler=cfg.get('handler'),
@@ -306,7 +308,7 @@ def create_function(cfg, path_to_zip_file):
         Environment={
             'Variables': {
                 key.strip('LAMBDA_'): value
-                for key, value in os.envinron.items()
+                for key, value in os.environ.items()
                 if key.startswith('LAMBDA_')
             }
         },

--- a/aws_lambda/aws_lambda.py
+++ b/aws_lambda/aws_lambda.py
@@ -333,7 +333,11 @@ def update_function(cfg, path_to_zip_file):
         Handler=cfg.get('handler'),
         Description=cfg.get('description'),
         Timeout=cfg.get('timeout', 15),
-        MemorySize=cfg.get('memory_size', 512)
+        MemorySize=cfg.get('memory_size', 512),
+        VpcConfig={
+            'SubnetIds': cfg.get('subnet_ids', []),
+            'SecurityGroupIds': cfg.get('security_group_ids', [])
+        }
     )
 
 


### PR DESCRIPTION
We use this package to deploy lambda functions for an in-house project. As of today we got the following error,

```
Starting new HTTPS connection (1): lambda.us-west-2.amazonaws.com
Updating your Lambda function
Starting new HTTPS connection (1): sts.amazonaws.com
Starting new HTTPS connection (1): lambda.us-west-2.amazonaws.com
Traceback (most recent call last):
  File "/home/travis/build/OpenTrons/foo-bar/lambdas/data-upload/venv/bin/lambda", line 53, in <module>
    cli()
  File "/home/travis/build/OpenTrons/foo-bar/lambdas/data-upload/venv/lib/python2.7/site-packages/click/core.py", line 716, in __call__
    return self.main(*args, **kwargs)
  File "/home/travis/build/OpenTrons/foo-bar/lambdas/data-upload/venv/lib/python2.7/site-packages/click/core.py", line 696, in main
    rv = self.invoke(ctx)
  File "/home/travis/build/OpenTrons/foo-bar/lambdas/data-upload/venv/lib/python2.7/site-packages/click/core.py", line 1060, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/travis/build/OpenTrons/foo-bar/lambdas/data-upload/venv/lib/python2.7/site-packages/click/core.py", line 889, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/travis/build/OpenTrons/foo-bar/lambdas/data-upload/venv/lib/python2.7/site-packages/click/core.py", line 534, in invoke
    return callback(*args, **kwargs)
  File "/home/travis/build/OpenTrons/foo-bar/lambdas/data-upload/venv/bin/lambda", line 39, in deploy
    aws_lambda.deploy(CURRENT_DIR, local_package)
  File "/home/travis/build/OpenTrons/foo-bar/lambdas/data-upload/venv/lib/python2.7/site-packages/aws_lambda/aws_lambda.py", line 86, in deploy
    update_function(cfg, path_to_zip_file)
  File "/home/travis/build/OpenTrons/foo-bar/lambdas/data-upload/venv/lib/python2.7/site-packages/aws_lambda/aws_lambda.py", line 336, in update_function
    MemorySize=cfg.get('memory_size', 512)
  File "/home/travis/build/OpenTrons/foo-bar/lambdas/data-upload/venv/lib/python2.7/site-packages/botocore/client.py", line 159, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/home/travis/build/OpenTrons/foo-bar/lambdas/data-upload/venv/lib/python2.7/site-packages/botocore/client.py", line 494, in _make_api_call
    raise ClientError(parsed_response, operation_name)
botocore.exceptions.ClientError: An error occurred (InvalidParameterValueException) when calling the UpdateFunctionConfiguration operation: SubnetIds and SecurityIds must coexist or be both empty list.
```

There's an active discussion on the error on the AWS Forums here: https://forums.aws.amazon.com/thread.jspa?threadID=246719

To fix this error I updated the lambda update configuration function to take empty lists or read lists from the configuration.