### PR TITLE
Adding the ability to deploy specific local directories; adding VpcConfig at create time

### DIFF
--- a/aws_lambda/aws_lambda.py
+++ b/aws_lambda/aws_lambda.py
@@ -316,6 +316,10 @@ def create_function(cfg, path_to_zip_file):
         Description=cfg.get('description'),
         Timeout=cfg.get('timeout', 15),
         MemorySize=cfg.get('memory_size', 512),
+        VpcConfig={
+            'SubnetIds': cfg.get('subnet_ids', []),
+            'SecurityGroupIds': cfg.get('security_group_ids', [])
+        },
         Environment={
             'Variables': {
                 key.strip('LAMBDA_'): value

--- a/aws_lambda/aws_lambda.py
+++ b/aws_lambda/aws_lambda.py
@@ -5,7 +5,7 @@ import logging
 import os
 import time
 from imp import load_source
-from shutil import copy, copyfile
+from shutil import copy, copyfile, copytree
 from tempfile import mkdtemp
 
 import botocore
@@ -180,6 +180,7 @@ def build(src, local_package=None):
                        else output_filename)
 
     files = []
+    dirs = []
     for filename in os.listdir(src):
         if os.path.isfile(filename):
             if filename == '.DS_Store':
@@ -187,6 +188,10 @@ def build(src, local_package=None):
             if filename == 'config.yaml':
                 continue
             files.append(os.path.join(src, filename))
+        elif os.path.isdir(filename) and filename in cfg.get('include_dirs', []):
+            if filename == 'dist':
+                continue
+            dirs.append(os.path.join(src, filename))
 
     # "cd" into `temp_path` directory.
     os.chdir(path_to_temp)
@@ -195,6 +200,12 @@ def build(src, local_package=None):
 
         # Copy handler file into root of the packages folder.
         copyfile(f, os.path.join(path_to_temp, filename))
+
+    for d in dirs:
+        _, dirname = os.path.split(d)
+
+        # Copy directory into root of the packages folder.
+        copytree(d, os.path.join(path_to_temp, dirname), symlinks=True)
 
     # Zip them together into a single file.
     # TODO: Delete temp directory created once the archive has been compiled.

--- a/aws_lambda/project_templates/config.yaml
+++ b/aws_lambda/project_templates/config.yaml
@@ -13,3 +13,4 @@ aws_secret_access_key:
 # dist_directory: dist
 # timeout: 15
 # memory_size: 512
+# include_dirs: []

--- a/aws_lambda/project_templates/config.yaml
+++ b/aws_lambda/project_templates/config.yaml
@@ -14,3 +14,5 @@ aws_secret_access_key:
 # timeout: 15
 # memory_size: 512
 # include_dirs: []
+# subnet_ids: []
+# security_group_ids: []


### PR DESCRIPTION
Added two small changes:

- Users can now set include_dirs in config file to allow specific local directories to get deployed. Until now only files got copied over.
- VpcConfig is now being set in create_function(), instead of only in update_function(). 