### PR TITLE
Composing path to bootstrap directory should be done with posixpath join

### DIFF
--- a/scripts/lambda
+++ b/scripts/lambda
@@ -47,11 +47,11 @@ def deploy(use_requirements, local_package):
     aws_lambda.deploy(CURRENT_DIR, use_requirements, local_package)
 
 
-
 @click.command(help="Delete old versions of your functions")
 @click.option("--keep-last", type=int, prompt="Please enter the number of recent versions to keep")
 def cleanup(keep_last):
     aws_lambda.cleanup_old_versions(CURRENT_DIR, keep_last)
+
 
 if __name__ == '__main__':
     cli.add_command(init)

--- a/scripts/lambda
+++ b/scripts/lambda
@@ -20,7 +20,7 @@ def cli():
 def init(folder):
     path = CURRENT_DIR
     if len(folder) > 0:
-        path = "{}/{}".format(CURRENT_DIR, folder[0])
+        path = os.path.join(CURRENT_DIR, *folder)
         if not os.path.exists(path):
             os.makedirs(path)
     aws_lambda.init(path)


### PR DESCRIPTION
Most of the people probably bootstrap the project giving no or just "basename"
folder to "lambda init" command, but if users would give full path as a folder,
the project will be created into working directory, but into several sub-directories.

So, not even a issue in most cases, but os.path.join would make it bit straight-forward?

Example:

        $ # current working directory
        $ pwd
        /Users/tanel/tmp/lambda
        $
        $ # no files of directories here
        $ tree
        .

        0 directories, 0 files
        $
        $ # just to see how bash replaces the ~
        $ echo lambda init ~/tmp/parent
        lambda init /Users/tanel/tmp/parent
        $
        $ # and now, lets executing it
        $ lambda init ~/tmp/parent
        $
        $ # result - bit odd sub-directory structure in working directory
        $ tree
        .
        └── Users
            └── tanel
                └── tmp
                    └── parent
                        ├── config.yaml
                        ├── event.json
                        └── service.py

        4 directories, 3 files
