### PR TITLE
Support for Python 3.6 & removing requirement to store secrets/environment values in the config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ docs/_build/
 
 # PyBuilder
 target/
+
+# Jetbrains/PyCharm project files
+.idea/

--- a/README.rst
+++ b/README.rst
@@ -13,9 +13,10 @@ python-λ
 Python-lambda is a toolset for developing and deploying *serverless* Python code in AWS Lambda.
 
 NOTE: CHANGES FROM BASE REPOSITORY
-============================
+==================================
 
 * Adding Python 3.6 support for the local environment & the lambda runtime
+* Supports "secret" environment variable values by reading them from the local environment during deploy instead of using hard-coded ones in the config file.
 
 
 A call for contributors
@@ -166,6 +167,13 @@ Lambda functions support environment variables. In order to set environment vari
   environment_variables:
     env1: foo
     env2: baz
+
+You can also keep "secrets" out of your config file by using the following syntax ``${}`` to read the values from your current/local environment.
+
+.. code:: yaml
+
+  environment_variables:
+    env3: ${LOCAL_ENVIRONMENT_VARIABLE_NAME}
 
 This would create environment variables in the lambda instance upon deploy. If your functions don't need environment variables, simply leave this section out of your config.
 

--- a/README.rst
+++ b/README.rst
@@ -12,6 +12,12 @@ python-λ
 
 Python-lambda is a toolset for developing and deploying *serverless* Python code in AWS Lambda.
 
+NOTE: CHANGES FROM BASE REPOSITORY
+============================
+
+* Adding Python 3.6 support for the local environment & the lambda runtime
+
+
 A call for contributors
 =======================
 With python-lambda and `pytube <https://github.com/nficano/pytube/>`_ both continuing to gain momentum, I'm calling for contributors to help build out new features, review pull requests, fix bugs, and maintain overall code quality. If you're interested, please email me at nficano[at]gmail.com.
@@ -28,7 +34,7 @@ The *Python-Lambda* library takes away the guess work of developing your Python-
 Requirements
 ============
 
-* Python 2.7 (At the time of writing this, AWS Lambda only supports Python 2.7).
+* Python 2.7 & 3.6 (At the time of writing this, AWS Lambda only supports Python 2.7/3.6).
 * Pip (~8.1.1)
 * Virtualenv (~15.0.0)
 * Virtualenvwrapper (~4.7.1)

--- a/README.rst
+++ b/README.rst
@@ -17,6 +17,7 @@ NOTE: CHANGES FROM BASE REPOSITORY
 
 * Adding Python 3.6 support for the local environment & the lambda runtime
 * Supports "secret" environment variable values by reading them from the local environment during deploy instead of using hard-coded ones in the config file.
+* You can install this version via pip with ``pip install --editable git+https://github.com/asaolabs/python-lambda#egg=python-lambda``
 
 
 A call for contributors

--- a/aws_lambda/aws_lambda.py
+++ b/aws_lambda/aws_lambda.py
@@ -344,7 +344,7 @@ def create_function(cfg, path_to_zip_file):
     """Register and upload a function to AWS Lambda."""
 
     print('Creating your new Lambda function')
-    byte_stream = read(path_to_zip_file)
+    byte_stream = read(path_to_zip_file, binary_file=True)
     aws_access_key_id = cfg.get('aws_access_key_id')
     aws_secret_access_key = cfg.get('aws_secret_access_key')
 
@@ -389,7 +389,7 @@ def update_function(cfg, path_to_zip_file):
     """Updates the code of an existing Lambda function"""
 
     print('Updating your Lambda function')
-    byte_stream = read(path_to_zip_file)
+    byte_stream = read(path_to_zip_file, binary_file=True)
     aws_access_key_id = cfg.get('aws_access_key_id')
     aws_secret_access_key = cfg.get('aws_secret_access_key')
 

--- a/aws_lambda/aws_lambda.py
+++ b/aws_lambda/aws_lambda.py
@@ -20,6 +20,7 @@ from .helpers import archive
 from .helpers import mkdir
 from .helpers import read
 from .helpers import timestamp
+from .helpers import get_environment_variable_value
 
 
 log = logging.getLogger(__name__)
@@ -375,7 +376,7 @@ def create_function(cfg, path_to_zip_file):
         kwargs.update(
             Environment={
                 'Variables': {
-                    key: value
+                    key: get_environment_variable_value(value)
                     for key, value
                     in cfg.get('environment_variables').items()
                 }
@@ -422,7 +423,7 @@ def update_function(cfg, path_to_zip_file):
         kwargs.update(
             Environment={
                 'Variables': {
-                    key: value
+                    key: get_environment_variable_value(value)
                     for key, value
                     in cfg.get('environment_variables').items()
                 }

--- a/aws_lambda/helpers.py
+++ b/aws_lambda/helpers.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
-import datetime as dt
 import os
 import zipfile
+import datetime as dt
 
 
 def mkdir(path):
@@ -9,8 +9,9 @@ def mkdir(path):
         os.makedirs(path)
 
 
-def read(path, loader=None):
-    with open(path) as fh:
+def read(path, loader=None, binary_file=False):
+    open_mode = 'rb' if binary_file else 'r'
+    with open(path, mode=open_mode) as fh:
         if not loader:
             return fh.read()
         return loader(fh.read())

--- a/aws_lambda/helpers.py
+++ b/aws_lambda/helpers.py
@@ -2,7 +2,7 @@
 import os
 import zipfile
 import datetime as dt
-
+import re
 
 def mkdir(path):
     if not os.path.exists(path):
@@ -31,3 +31,12 @@ def archive(src, dest, filename):
 def timestamp(fmt='%Y-%m-%d-%H%M%S'):
     now = dt.datetime.utcnow()
     return now.strftime(fmt)
+
+
+def get_environment_variable_value(val):
+    env_val = val
+    if val is not None and isinstance(val, str):
+        match = re.search(r'^\${(?P<environment_key_name>\w+)*}$', val)
+        if match is not None:
+            env_val = os.environ.get(match.group('environment_key_name'))
+    return env_val

--- a/aws_lambda/project_templates/config.yaml
+++ b/aws_lambda/project_templates/config.yaml
@@ -4,6 +4,7 @@ function_name: my_lambda_function
 handler: service.handler
 # role: lambda_basic_execution
 description: My first lambda function
+runtime: python2.7
 
 # if access key and secret are left blank, boto will use the credentials
 # defined in the [default] section of ~/.aws/credentials.
@@ -14,6 +15,7 @@ aws_secret_access_key:
 # timeout: 15
 # memory_size: 512
 #
+
 # Experimental Environment variables
 environment_variables:
     env_1: foo


### PR DESCRIPTION
**Python 3.6 Support (Local Environment)**
Building and deploying lambda functions wasn't working with python3.6.  The issue was that the default encoding for files is UTF-8 and we're opening up the zip files to create or update a function.  We were getting the following error in the read() method in the helper module.

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File ".../python3.6/codecs.py", line 321, in decode
    (result, consumed) = self._buffer_decode(data, self.errors, final)
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xe5 in position 12: invalid continuation byte
```
I added an optional parameter to the helper.py read() call that defines whether the file is binary or not.  This allows us to read the zip file during deployment.

To assist users that are using the python3.6 runtime, I also added the default "runtime" value to the config.yaml file (making it more obvious where the configuration for the runtime is)

**"Secret" Environment Variable Values**
To match our best practices of not including "secrets" in any files checked into our code repository, I added the ability to load environment variable values from the local environment instead of having them hard-coded in the config file.  This is just a change in the way the value is defined.  Environment values can be set using the following syntax (see env3) and the values are read at deploy time.

```
environment_variables:
  env_1: foo
  env_2: baz
  env3: ${LOCAL_ENVIRONMENT_VARIABLE_NAME}
```
