### PR TITLE
Adding function to upload zip file to S3

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -165,6 +165,16 @@ value for the environment variable at the time of deployment (instead of hard co
 
 This would create environment variables in the lambda instance upon deploy. If your functions don't need environment variables, simply leave this section out of your config.
 
+Uploading to S3
+===============
+You may find that you do not need the toolkit to fully deploy your Lambda or that your code bundle is too large to upload via the API.  You can use the `upload` command to send the bundle to an S3 bucket of your choosing.
+Before doing this, you will need to set the following variables in `config.yaml`:
+```
+role: basic_s3_upload
+bucket_name: 'example-bucket'
+s3_key_prefix: 'path/to/file/'
+```
+Your role must have `s3:PutObject` permission on the bucket/key that you specify for the upload to work properly. Once you have that set, you can execute `lambda upload` to initiate the transfer.
 
 Development
 ===========

--- a/aws_lambda/__init__.py
+++ b/aws_lambda/__init__.py
@@ -4,7 +4,7 @@ __author__ = 'Nick Ficano'
 __email__ = 'nficano@gmail.com'
 __version__ = '1.0.1'
 
-from .aws_lambda import deploy, invoke, init, build, cleanup_old_versions
+from .aws_lambda import deploy, invoke, init, build, upload, cleanup_old_versions
 
 # Set default logging handler to avoid "No handler found" warnings.
 import logging

--- a/aws_lambda/aws_lambda.py
+++ b/aws_lambda/aws_lambda.py
@@ -475,14 +475,13 @@ def upload_s3(cfg, path_to_zip_file):
         os.environ.get('LAMBDA_FUNCTION_NAME') or cfg.get('function_name')
     )
     kwargs = {
-        'Bucket': cfg.get('bucket_name'),
+        'Bucket': '{}'.format(buck_name),
         'Key': cfg.get('s3_key', '{}.zip'.format(func_name)),
         'Body': byte_stream
     }
 
     client.put_object(**kwargs)
     print('Finished uploading {} to S3 bucket {}'.format(func_name, buck_name))
-
 
 def function_exists(cfg, function_name):
     """Check whether a function exists or not"""

--- a/aws_lambda/aws_lambda.py
+++ b/aws_lambda/aws_lambda.py
@@ -15,7 +15,7 @@ import boto3
 import botocore
 import pip
 import yaml
-import md5
+import hashlib
 
 from .helpers import archive
 from .helpers import mkdir
@@ -468,7 +468,7 @@ def upload_s3(cfg, path_to_zip_file):
     with open(path_to_zip_file, mode='rb') as fh:
         byte_stream = fh.read()
     s3_key_prefix = cfg.get('s3_key_prefix', '/dist')
-    checksum = md5.new(byte_stream).hexdigest()
+    checksum = hashlib.new('md5', byte_stream).hexdigest()
     timestamp = str(time.time())
     filename = '{prefix}{checksum}-{ts}.zip'.format(prefix=s3_key_prefix, checksum=checksum, ts=timestamp)
 

--- a/aws_lambda/aws_lambda.py
+++ b/aws_lambda/aws_lambda.py
@@ -476,8 +476,8 @@ def upload_s3(cfg, path_to_zip_file):
     )
     kwargs = {
         'Bucket': cfg.get('bucket_name'),
-        'Key': cfg.get('s3_key', '{}'.format(func_name)),
-        'Body': {'ZipFile': byte_stream}
+        'Key': cfg.get('s3_key', '{}.zip'.format(func_name)),
+        'Body': byte_stream
     }
 
     client.put_object(**kwargs)

--- a/aws_lambda/aws_lambda.py
+++ b/aws_lambda/aws_lambda.py
@@ -471,7 +471,6 @@ def upload_s3(cfg, path_to_zip_file):
     checksum = md5.new(byte_stream).hexdigest()
     timestamp = str(time.time())
     filename = '{prefix}{checksum}-{ts}.zip'.format(prefix=s3_key_prefix, checksum=checksum, ts=timestamp)
-    print(filename)
 
     # Do we prefer development variable over config?
     buck_name = (

--- a/aws_lambda/project_templates/config.yaml
+++ b/aws_lambda/project_templates/config.yaml
@@ -3,6 +3,8 @@ region: us-east-1
 function_name: my_lambda_function
 handler: service.handler
 # role: lambda_basic_execution
+# bucket_name: my_s3_bucket
+# s3_key: 'path/to/file.zip'
 description: My first lambda function
 runtime: python2.7
 

--- a/aws_lambda/project_templates/config.yaml
+++ b/aws_lambda/project_templates/config.yaml
@@ -2,11 +2,14 @@ region: us-east-1
 
 function_name: my_lambda_function
 handler: service.handler
-# role: lambda_basic_execution
-# bucket_name: my_s3_bucket
-# s3_key: 'path/to/file.zip'
 description: My first lambda function
 runtime: python2.7
+# role: lambda_basic_execution
+
+# S3 upload requires appropriate role with s3:PutObject permission
+# (ex. basic_s3_upload), a destination bucket, and the key prefix
+# bucket_name: 'example-bucket'
+# s3_key_prefix: 'path/to/file/'
 
 # if access key and secret are left blank, boto will use the credentials
 # defined in the [default] section of ~/.aws/credentials.

--- a/scripts/lambda
+++ b/scripts/lambda
@@ -46,7 +46,11 @@ def invoke(event_file, verbose):
 def deploy(use_requirements, local_package):
     aws_lambda.deploy(CURRENT_DIR, use_requirements, local_package)
 
-
+@click.command(help="Upload your lambda to S3.")
+@click.option('--use-requirements', default=False, is_flag=True, help='Install all packages defined in requirements.txt')
+@click.option('--local-package', default=None, help='Install local package as well.', type=click.Path(), multiple=True)
+def upload(use_requirements, local_package):
+    aws_lambda.upload(CURRENT_DIR, use_requirements, local_package)
 
 @click.command(help="Delete old versions of your functions")
 @click.option("--keep-last", type=int, prompt="Please enter the number of recent versions to keep")
@@ -57,6 +61,7 @@ if __name__ == '__main__':
     cli.add_command(init)
     cli.add_command(invoke)
     cli.add_command(deploy)
+    cli.add_command(upload)
     cli.add_command(build)
     cli.add_command(cleanup)
     cli()


### PR DESCRIPTION
Please feel free to close if this is deemed unnecessary.  

This is a great toolkit, however, we've been using other tools to deploy/manage lambda configurations.  I found that I simply need this toolkit to upload the zipped file to S3 instead of actually deploying the lambda itself.  I tried to stay within patterns already established in this repo so this PR may look a little copy/paste-y.  Provided that the user adds the destination S3 bucket (and the optional key) to `config.yaml`, he or she can just execute `lambda upload` to build the zip file and send it off to S3.

Any feedback would be much appreciated.