### PR TITLE
Including Source folders in the deployment zip package (build process)

### DIFF
--- a/aws_lambda/aws_lambda.py
+++ b/aws_lambda/aws_lambda.py
@@ -9,8 +9,9 @@ import sys
 import time
 from imp import load_source
 from shutil import copy
-from shutil import copyfile
+from shutil import copyfile, copytree
 from tempfile import mkdtemp
+from collections import defaultdict
 
 import boto3
 import botocore
@@ -242,6 +243,10 @@ def build(src, requirements=False, local_package=None):
         else output_filename
     )
 
+    # Allow definition of source code directories we want to build into our zipped package.
+    build_config = defaultdict(**cfg.get('build', {}))
+    source_directories = [d.strip() for d in build_config.get('source_directories', '').split(',')]
+
     files = []
     for filename in os.listdir(src):
         if os.path.isfile(filename):
@@ -249,17 +254,21 @@ def build(src, requirements=False, local_package=None):
                 continue
             if filename == 'config.yaml':
                 continue
-        # TODO: Check subdirectories for '.DS_Store' files
-        print('Bundling: %r' % filename)
-        files.append(os.path.join(src, filename))
+        elif os.path.isdir(filename) and filename in source_directories:
+            print('Bundling directory: %r' % filename)
+            files.append(os.path.join(src, filename))
 
     # "cd" into `temp_path` directory.
     os.chdir(path_to_temp)
     for f in files:
-        _, filename = os.path.split(f)
+        if os.path.isfile(f):
+            _, filename = os.path.split(f)
 
-        # Copy handler file into root of the packages folder.
-        copyfile(f, os.path.join(path_to_temp, filename))
+            # Copy handler file into root of the packages folder.
+            copyfile(f, os.path.join(path_to_temp, filename))
+        elif os.path.isdir(f):
+            destination_folder = os.path.join(path_to_temp, f[len(src) + 1:])
+            copytree(f, destination_folder)
 
     # Zip them together into a single file.
     # TODO: Delete temp directory created once the archive has been compiled.

--- a/aws_lambda/aws_lambda.py
+++ b/aws_lambda/aws_lambda.py
@@ -9,8 +9,9 @@ import sys
 import time
 from imp import load_source
 from shutil import copy
-from shutil import copyfile
+from shutil import copyfile, copytree
 from tempfile import mkdtemp
+from collections import defaultdict
 
 import boto3
 import botocore
@@ -242,6 +243,10 @@ def build(src, requirements=False, local_package=None):
         else output_filename
     )
 
+    # Allow definition of source code directories we want to build into our zipped package.
+    build_config = defaultdict(**cfg.get('build', {}))
+    source_directories = [d.strip() for d in build_config.get('source_directories', '').split(',')]
+
     files = []
     for filename in os.listdir(src):
         if os.path.isfile(filename):
@@ -249,17 +254,23 @@ def build(src, requirements=False, local_package=None):
                 continue
             if filename == 'config.yaml':
                 continue
-        # TODO: Check subdirectories for '.DS_Store' files
-        print('Bundling: %r' % filename)
-        files.append(os.path.join(src, filename))
+            print('Bundling: %r' % filename)
+            files.append(os.path.join(src, filename))
+        elif os.path.isdir(filename) and filename in source_directories:
+            print('Bundling directory: %r' % filename)
+            files.append(os.path.join(src, filename))
 
     # "cd" into `temp_path` directory.
     os.chdir(path_to_temp)
     for f in files:
-        _, filename = os.path.split(f)
+        if os.path.isfile(f):
+            _, filename = os.path.split(f)
 
-        # Copy handler file into root of the packages folder.
-        copyfile(f, os.path.join(path_to_temp, filename))
+            # Copy handler file into root of the packages folder.
+            copyfile(f, os.path.join(path_to_temp, filename))
+        elif os.path.isdir(f):
+            destination_folder = os.path.join(path_to_temp, f[len(src) + 1:])
+            copytree(f, destination_folder)
 
     # Zip them together into a single file.
     # TODO: Delete temp directory created once the archive has been compiled.

--- a/aws_lambda/aws_lambda.py
+++ b/aws_lambda/aws_lambda.py
@@ -245,7 +245,9 @@ def build(src, requirements=False, local_package=None):
 
     # Allow definition of source code directories we want to build into our zipped package.
     build_config = defaultdict(**cfg.get('build', {}))
-    source_directories = [d.strip() for d in build_config.get('source_directories', '').split(',')]
+    build_source_directories = build_config.get('source_directories', '')
+    build_source_directories = build_source_directories if build_source_directories is not None else ''
+    source_directories = [d.strip() for d in build_source_directories.split(',')]
 
     files = []
     for filename in os.listdir(src):

--- a/aws_lambda/project_templates/config.yaml
+++ b/aws_lambda/project_templates/config.yaml
@@ -25,3 +25,7 @@ aws_secret_access_key:
 environment_variables:
     env_1: foo
     env_2: baz
+
+# Build options
+build:
+  include_source_directories: lib # a common delimited list of directories in your project root that contains source to package.

--- a/aws_lambda/project_templates/config.yaml
+++ b/aws_lambda/project_templates/config.yaml
@@ -25,3 +25,7 @@ aws_secret_access_key:
 environment_variables:
     env_1: foo
     env_2: baz
+
+# Build options
+build:
+  source_directories: lib # a comma delimited list of directories in your project root that contains source to package.

--- a/aws_lambda/project_templates/config.yaml
+++ b/aws_lambda/project_templates/config.yaml
@@ -25,7 +25,3 @@ aws_secret_access_key:
 environment_variables:
     env_1: foo
     env_2: baz
-
-# Build options
-build:
-  include_source_directories: lib # a common delimited list of directories in your project root that contains source to package.


### PR DESCRIPTION
This is related to issue #64 not working as expected.  Added the capability to copy source directories into the zip package in the build process.  To control which folders are copied (as there may be additional folders that shouldn't be deployed within the project structure), there is a new build configuration section in the config.yaml file that includes a new property "source_directories".  

_Note: This makes it much easier to build a lambda function that talks to Redshift/Postgres databases using the precompiled psycopg2._