### PR TITLE
fix exception on invoke when no env vars found in config

### DIFF
--- a/aws_lambda/aws_lambda.py
+++ b/aws_lambda/aws_lambda.py
@@ -144,8 +144,10 @@ def invoke(src, alt_event=None, verbose=False):
 
     # Load environment variables from the config file into the actual
     # environment.
-    for key, value in cfg.get('environment_variables').items():
-        os.environ[key] = value
+    env_vars = cfg.get('environment_variables')
+    if env_vars:
+        for key, value in env_vars.items():
+            os.environ[key] = value
 
     # Load and parse event file.
     if alt_event:


### PR DESCRIPTION
This should fix issue https://github.com/nficano/python-lambda/issues/71 , please review