### PR TITLE
Selectively install futures package based on Python version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 import pip
+import sys
 from setuptools import find_packages
 from setuptools import setup
 
@@ -10,7 +11,12 @@ with open('README.rst') as readme_file:
 requirements = pip.req.parse_requirements(
     'requirements.txt', session=pip.download.PipSession(),
 )
-pip_requirements = [str(r.req) for r in requirements]
+
+# Only install futures package if using a Python version <= 2.7
+if sys.version_info[0] == 2:
+    pip_requirements = [str(r.req) for r in requirements]
+else:
+    pip_requirements = [str(r.req) for r in requirements if 'futures' not in str(r.req)]
 
 test_requirements = [
     # TODO: put package test requirements here


### PR DESCRIPTION
Currently, the `futures` package is installed via `requirements.txt` any time python-lambda is installed.  The `futures` package, however, is a back port of functionality found in Python 3's standard library, and is only intended to be used with Python versions <= 2.7.

This PR updates the `setup.py` file to only include the `futures` package in the `python-lambda` install only when Python 2 is being used.

This closes issue #59 