### PR TITLE
adding region to `get_account_id` avoid failures

### DIFF
--- a/aws_lambda/aws_lambda.py
+++ b/aws_lambda/aws_lambda.py
@@ -439,9 +439,12 @@ def get_role_name(region, account_id, role):
     return 'arn:{0}:iam::{1}:role/{2}'.format(prefix, account_id, role)
 
 
-def get_account_id(aws_access_key_id, aws_secret_access_key):
+def get_account_id(aws_access_key_id, aws_secret_access_key,region=None):
     """Query STS for a users' account_id"""
-    client = get_client('sts', aws_access_key_id, aws_secret_access_key)
+    client = get_client(
+        'sts', aws_access_key_id, aws_secret_access_key,
+        region
+    )
     return client.get_caller_identity().get('Account')
 
 
@@ -464,7 +467,7 @@ def create_function(cfg, path_to_zip_file, *use_s3, **s3_file):
     aws_access_key_id = cfg.get('aws_access_key_id')
     aws_secret_access_key = cfg.get('aws_secret_access_key')
 
-    account_id = get_account_id(aws_access_key_id, aws_secret_access_key)
+    account_id = get_account_id(aws_access_key_id, aws_secret_access_key,cfg.get('region'))
     role = get_role_name(
         cfg.get('region'), account_id,
         cfg.get('role', 'lambda_basic_execution'),
@@ -534,7 +537,7 @@ def update_function(cfg, path_to_zip_file, *use_s3, **s3_file):
     aws_access_key_id = cfg.get('aws_access_key_id')
     aws_secret_access_key = cfg.get('aws_secret_access_key')
 
-    account_id = get_account_id(aws_access_key_id, aws_secret_access_key)
+    account_id = get_account_id(aws_access_key_id, aws_secret_access_key, cfg.get('region'))
     role = get_role_name(
         cfg.get('region'), account_id,
         cfg.get('role', 'lambda_basic_execution'),


### PR DESCRIPTION
While using `lambda deploy` I was getting error:

```python
(getreportdata)aameer@falcon:~/Documents/projects/getreportdata$ lambda deploy
Gathering pip packages
Installing boto3==1.4.4
Installing botocore==1.5.62
Installing certifi==2017.11.5
Installing chardet==3.0.4
Installing click==6.6
Installing docutils==0.12
Installing futures==3.0.5
Installing idna==2.6
Installing jmespath==0.9.0
Installing pyaml==15.8.2
Installing python-dateutil==2.5.3
Installing PyYAML==3.11
Installing requests==2.18.4
Installing s3transfer==0.1.11
Installing six==1.10.0
Installing urllib3==1.22
Bundling: 'event.json'
Bundling: 'service.pyc'
Bundling: 'service.py'
Starting new HTTPS connection (1): lambda.us-east-1.amazonaws.com
Updating your Lambda function
Starting new HTTPS connection (1): sts.us-east-1c.amazonaws.com
Starting new HTTPS connection (2): sts.us-east-1c.amazonaws.com
Starting new HTTPS connection (3): sts.us-east-1c.amazonaws.com
Starting new HTTPS connection (4): sts.us-east-1c.amazonaws.com
Starting new HTTPS connection (5): sts.us-east-1c.amazonaws.com
Traceback (most recent call last):
  File "/home/aameer/.virtualenvs/getreportdata/bin/lambda", line 101, in <module>
    cli()
  File "/home/aameer/.virtualenvs/getreportdata/local/lib/python2.7/site-packages/click/core.py", line 716, in __call__
    return self.main(*args, **kwargs)
  File "/home/aameer/.virtualenvs/getreportdata/local/lib/python2.7/site-packages/click/core.py", line 696, in main
    rv = self.invoke(ctx)
  File "/home/aameer/.virtualenvs/getreportdata/local/lib/python2.7/site-packages/click/core.py", line 1060, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/aameer/.virtualenvs/getreportdata/local/lib/python2.7/site-packages/click/core.py", line 889, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/aameer/.virtualenvs/getreportdata/local/lib/python2.7/site-packages/click/core.py", line 534, in invoke
    return callback(*args, **kwargs)
  File "/home/aameer/.virtualenvs/getreportdata/bin/lambda", line 66, in deploy
    aws_lambda.deploy(CURRENT_DIR, use_requirements, local_package)
  File "/home/aameer/.virtualenvs/getreportdata/local/lib/python2.7/site-packages/aws_lambda/aws_lambda.py", line 102, in deploy
    update_function(cfg, path_to_zip_file)
  File "/home/aameer/.virtualenvs/getreportdata/local/lib/python2.7/site-packages/aws_lambda/aws_lambda.py", line 522, in update_function
    account_id = get_account_id(aws_access_key_id, aws_secret_access_key)
  File "/home/aameer/.virtualenvs/getreportdata/local/lib/python2.7/site-packages/aws_lambda/aws_lambda.py", line 431, in get_account_id
    return client.get_caller_identity().get('Account')
  File "/home/aameer/.virtualenvs/getreportdata/local/lib/python2.7/site-packages/botocore/client.py", line 253, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/home/aameer/.virtualenvs/getreportdata/local/lib/python2.7/site-packages/botocore/client.py", line 544, in _make_api_call
    operation_model, request_dict)
  File "/home/aameer/.virtualenvs/getreportdata/local/lib/python2.7/site-packages/botocore/endpoint.py", line 141, in make_request
    return self._send_request(request_dict, operation_model)
  File "/home/aameer/.virtualenvs/getreportdata/local/lib/python2.7/site-packages/botocore/endpoint.py", line 170, in _send_request
    success_response, exception):
  File "/home/aameer/.virtualenvs/getreportdata/local/lib/python2.7/site-packages/botocore/endpoint.py", line 249, in _needs_retry
    caught_exception=caught_exception, request_dict=request_dict)
  File "/home/aameer/.virtualenvs/getreportdata/local/lib/python2.7/site-packages/botocore/hooks.py", line 227, in emit
    return self._emit(event_name, kwargs)
  File "/home/aameer/.virtualenvs/getreportdata/local/lib/python2.7/site-packages/botocore/hooks.py", line 210, in _emit
    response = handler(**kwargs)
  File "/home/aameer/.virtualenvs/getreportdata/local/lib/python2.7/site-packages/botocore/retryhandler.py", line 183, in __call__
    if self._checker(attempts, response, caught_exception):
  File "/home/aameer/.virtualenvs/getreportdata/local/lib/python2.7/site-packages/botocore/retryhandler.py", line 251, in __call__
    caught_exception)
  File "/home/aameer/.virtualenvs/getreportdata/local/lib/python2.7/site-packages/botocore/retryhandler.py", line 277, in _should_retry
    return self._checker(attempt_number, response, caught_exception)
  File "/home/aameer/.virtualenvs/getreportdata/local/lib/python2.7/site-packages/botocore/retryhandler.py", line 317, in __call__
    caught_exception)
  File "/home/aameer/.virtualenvs/getreportdata/local/lib/python2.7/site-packages/botocore/retryhandler.py", line 223, in __call__
    attempt_number, caught_exception)
  File "/home/aameer/.virtualenvs/getreportdata/local/lib/python2.7/site-packages/botocore/retryhandler.py", line 359, in _check_caught_exception
    raise caught_exception
botocore.exceptions.EndpointConnectionError: Could not connect to the endpoint URL: "https://sts.us-east-1c.amazonaws.com/"
(getreportdata)aameer@falcon:~/Documents/projects/getreportdata$ 
```
while checking on SO i saw this (https://stackoverflow.com/questions/40409683/aws-s3-cli-could-not-connect-to-the-endpoint-url) , where Henri proposed that it has something to do with default region ( Note I had added `region: us-east-1` in `config.yaml`). So I added region to 
to `get_account_id` and that seemed to resolved it.