### PR TITLE
Strong cast environment variables to type string

### DIFF
--- a/aws_lambda/aws_lambda.py
+++ b/aws_lambda/aws_lambda.py
@@ -585,7 +585,7 @@ def update_function(cfg, path_to_zip_file, *use_s3, **s3_file):
         kwargs.update(
             Environment={
                 'Variables': {
-                    key: get_environment_variable_value(value)
+                    key: str(get_environment_variable_value(value))
                     for key, value
                     in cfg.get('environment_variables').items()
                 },


### PR DESCRIPTION
If an environment variable is added to the config, which is just a number, it is decoded from YAML into an int which causes a botocore.exceptions.ParamValidationError

Here is the relevant part of the stack trace:

botocore/validate.py", line 291, in serialize_to_request
    raise ParamValidationError(report=report.generate_report())
botocore.exceptions.ParamValidationError: Parameter validation failed:
Invalid type for parameter Environment.Variables.lowThreshold, value: 5, type: <class 'int'>, valid types: <class 'str'>

When I changed the relevant code, casting `get_environment_variable_value(value)` to type `str`, it  succeeded in uploading the intended environment variable to AWS without errors.
  