### PR TITLE
Idea/Tentative Change: Don't set role by default

### DIFF
--- a/aws_lambda/aws_lambda.py
+++ b/aws_lambda/aws_lambda.py
@@ -436,7 +436,7 @@ def pip_install_to_target(path, use_requirements=False, local_package=None):
 def get_role_name(region, account_id, role):
     """Shortcut to insert the `account_id` and `role` into the iam string."""
     prefix = ARN_PREFIXES.get(region, 'aws')
-    return 'arn:{0}:iam::{1}:role/{2}'.format(prefix, account_id, role)
+    return None if role == "noRoleSet" else 'arn:{0}:iam::{1}:role/{2}'.format(prefix, account_id, role)
 
 
 def get_account_id(aws_access_key_id, aws_secret_access_key, region=None):
@@ -472,7 +472,7 @@ def create_function(cfg, path_to_zip_file, *use_s3, **s3_file):
     )
     role = get_role_name(
         cfg.get('region'), account_id,
-        cfg.get('role', 'lambda_basic_execution'),
+        cfg.get('role', 'noRoleSet'),
     )
 
     client = get_client(
@@ -517,6 +517,9 @@ def create_function(cfg, path_to_zip_file, *use_s3, **s3_file):
             'Publish': True,
         }
 
+    if not role:
+        kwargs.pop('Role')
+        
     if 'environment_variables' in cfg:
         kwargs.update(
             Environment={
@@ -584,6 +587,9 @@ def update_function(cfg, path_to_zip_file, *use_s3, **s3_file):
             'SecurityGroupIds': cfg.get('security_group_ids', []),
         },
     }
+    
+    if not role:
+        kwargs.pop('Role')
 
     if 'environment_variables' in cfg:
         kwargs.update(


### PR DESCRIPTION
If the user wants to manage the role through the AWS web interface, or doesn't want to give the user updating the function the iam:PassRole permission for security, don't try to change the role back to lambda_basic_execution.  If the role is not defined in the config, it will not be updated on Lambda.  If more checks like this are implemented they might be moved to a dedicated part of the code.