### PR TITLE
Add the ability to set tags on a function

### DIFF
--- a/aws_lambda/aws_lambda.py
+++ b/aws_lambda/aws_lambda.py
@@ -641,8 +641,9 @@ def update_function(
             for key, value in cfg.get('tags').items()
         }
         if tags != existing_cfg.get('Tags'):
-            client.untag_resource(Resource=ret['FunctionArn'],
-                                  TagKeys=list(existing_cfg['Tags'].keys()))
+            if existing_cfg.get('Tags'):
+                client.untag_resource(Resource=ret['FunctionArn'],
+                                      TagKeys=list(existing_cfg['Tags'].keys()))
             client.tag_resource(Resource=ret['FunctionArn'], Tags=tags)
 
 

--- a/aws_lambda/aws_lambda.py
+++ b/aws_lambda/aws_lambda.py
@@ -640,7 +640,7 @@ def update_function(
             key: str(value)
             for key, value in cfg.get('tags').items()
         }
-        if tags != existing_cfg['Tags']:
+        if tags != existing_cfg.get('Tags'):
             client.untag_resource(Resource=ret['FunctionArn'],
                                   TagKeys=list(existing_cfg['Tags'].keys()))
             client.tag_resource(Resource=ret['FunctionArn'], Tags=tags)

--- a/aws_lambda/aws_lambda.py
+++ b/aws_lambda/aws_lambda.py
@@ -109,8 +109,9 @@ def deploy(
         local_package=local_package,
     )
 
-    if function_exists(cfg):
-        update_function(cfg, path_to_zip_file)
+    existing_config = get_function_config(cfg)
+    if existing_config:
+        update_function(cfg, path_to_zip_file, existing_config)
     else:
         create_function(cfg, path_to_zip_file)
 
@@ -143,8 +144,10 @@ def deploy_s3(
 
     use_s3 = True
     s3_file = upload_s3(cfg, path_to_zip_file, use_s3)
-    if function_exists(cfg):
-        update_function(cfg, path_to_zip_file, use_s3=use_s3, s3_file=s3_file)
+    existing_config = get_function_config(cfg)
+    if existing_config:
+        update_function(cfg, path_to_zip_file, existing_config, use_s3=use_s3,
+                        s3_file=s3_file)
     else:
         create_function(cfg, path_to_zip_file, use_s3=use_s3, s3_file=s3_file)
 
@@ -538,6 +541,14 @@ def create_function(cfg, path_to_zip_file, use_s3=False, s3_file=None):
             'Publish': True,
         }
 
+    if 'tags' in cfg:
+        kwargs.update(
+            Tags={
+                key: str(value)
+                for key, value in cfg.get('tags').items()
+            }
+        )
+
     if 'environment_variables' in cfg:
         kwargs.update(
             Environment={
@@ -552,7 +563,9 @@ def create_function(cfg, path_to_zip_file, use_s3=False, s3_file=None):
     client.create_function(**kwargs)
 
 
-def update_function(cfg, path_to_zip_file, use_s3=False, s3_file=None):
+def update_function(
+        cfg, path_to_zip_file, existing_cfg, use_s3=False, s3_file=None
+):
     """Updates the code of an existing Lambda function"""
 
     print('Updating your Lambda function')
@@ -620,7 +633,17 @@ def update_function(cfg, path_to_zip_file, use_s3=False, s3_file=None):
             },
         )
 
-    client.update_function_configuration(**kwargs)
+    ret = client.update_function_configuration(**kwargs)
+
+    if 'tags' in cfg:
+        tags = {
+            key: str(value)
+            for key, value in cfg.get('tags').items()
+        }
+        if tags != existing_cfg['Tags']:
+            client.untag_resource(Resource=ret['FunctionArn'],
+                                  TagKeys=existing_cfg['Tags'].keys())
+            client.tag_resource(Resource=ret['FunctionArn'], Tags=tags)
 
 
 def upload_s3(cfg, path_to_zip_file, *use_s3):
@@ -663,8 +686,8 @@ def upload_s3(cfg, path_to_zip_file, *use_s3):
         return filename
 
 
-def function_exists(cfg):
-    """Check whether a function exists or not"""
+def get_function_config(cfg):
+    """Check whether a function exists or not and return its config"""
 
     function_name = cfg.get('function_name')
     profile_name = cfg.get('profile')
@@ -680,6 +703,7 @@ def function_exists(cfg):
     except client.exceptions.ResourceNotFoundException as e:
         if 'Function not found' in str(e):
             return False
+
 
 def read_cfg(path_to_config_file, profile_name):
     cfg = read(path_to_config_file, loader=yaml.load)

--- a/aws_lambda/aws_lambda.py
+++ b/aws_lambda/aws_lambda.py
@@ -642,7 +642,7 @@ def update_function(
         }
         if tags != existing_cfg['Tags']:
             client.untag_resource(Resource=ret['FunctionArn'],
-                                  TagKeys=existing_cfg['Tags'].keys())
+                                  TagKeys=list(existing_cfg['Tags'].keys()))
             client.tag_resource(Resource=ret['FunctionArn'], Tags=tags)
 
 

--- a/aws_lambda/project_templates/config.yaml
+++ b/aws_lambda/project_templates/config.yaml
@@ -26,6 +26,13 @@ environment_variables:
     env_1: foo
     env_2: baz
 
+# If `tags` is uncommented then tags will be set at creation or update
+# time.  During an update all other tags will be removed except the tags
+# listed here.
+#tags:
+#    tag_1: foo
+#    tag_2: bar
+
 # Build options
 build:
   source_directories: lib # a comma delimited list of directories in your project root that contains source to package.


### PR DESCRIPTION
This might need a little more polish, but I added the ability to set/update tags on a function.

The behavior for a new function is straightforward because `create_function` accepts a `Tags` keyword.

For `update_function_configuration` it's a little trickier since that does not accept `Tags`.  The implementation I chose is to only update the existing tags if `tags` is set in the config.  If so, all existing tags are wiped and the supplied ones are applied.  If `tags` is not set in the config then the tags are left alone.

Update - on further thought perhaps tags should be applied on an update, but existing ones should be left alone.  Thoughts?