### PR TITLE
Change --use-requirements to --requirements <PATH> (#86)

### DIFF
--- a/aws_lambda/aws_lambda.py
+++ b/aws_lambda/aws_lambda.py
@@ -83,7 +83,7 @@ def cleanup_old_versions(
 
 
 def deploy(
-        src, use_requirements=False, local_package=None,
+        src, requirements=None, local_package=None,
         config_file='config.yaml', profile_name=None,
 ):
     """Deploys a new function to AWS Lambda.
@@ -105,7 +105,7 @@ def deploy(
     # directory.
     path_to_zip_file = build(
         src, config_file=config_file,
-        use_requirements=use_requirements,
+        requirements=requirements,
         local_package=local_package,
     )
 
@@ -116,7 +116,7 @@ def deploy(
 
 
 def deploy_s3(
-    src, use_requirements=False, local_package=None,
+    src, requirements=None, local_package=None,
     config_file='config.yaml', profile_name=None,
 ):
     """Deploys a new function via AWS S3.
@@ -137,7 +137,7 @@ def deploy_s3(
     # Zip the contents of this folder into a single file and output to the dist
     # directory.
     path_to_zip_file = build(
-        src, config_file=config_file, use_requirements=use_requirements,
+        src, config_file=config_file, requirements=requirements,
         local_package=local_package,
     )
 
@@ -150,7 +150,7 @@ def deploy_s3(
 
 
 def upload(
-        src, use_requirements=False, local_package=None,
+        src, requirements=None, local_package=None,
         config_file='config.yaml', profile_name=None,
 ):
     """Uploads a new function to AWS S3.
@@ -171,7 +171,7 @@ def upload(
     # Zip the contents of this folder into a single file and output to the dist
     # directory.
     path_to_zip_file = build(
-        src, config_file=config_file, use_requirements=use_requirements,
+        src, config_file=config_file, requirements=requirements,
         local_package=local_package,
     )
 
@@ -258,7 +258,7 @@ def init(src, minimal=False):
 
 
 def build(
-    src, use_requirements=False, local_package=None,
+    src, requirements=None, local_package=None,
     config_file='config.yaml', profile_name=None,
 ):
     """Builds the file bundle.
@@ -288,7 +288,7 @@ def build(
     path_to_temp = mkdtemp(prefix='aws-lambda')
     pip_install_to_target(
         path_to_temp,
-        use_requirements=use_requirements,
+        requirements=requirements,
         local_package=local_package,
     )
 
@@ -407,30 +407,28 @@ def _install_packages(path, packages):
         pip.main(['install', package, '-t', path, '--ignore-installed'])
 
 
-def pip_install_to_target(path, use_requirements=False, local_package=None):
+def pip_install_to_target(path, requirements=None, local_package=None):
     """For a given active virtualenv, gather all installed pip packages then
     copy (re-install) them to the path provided.
 
     :param str path:
         Path to copy installed pip packages to.
-    :param bool use_requirements:
-        If set, only the packages in the requirements.txt file are installed.
-        The requirements.txt file needs to be in the same directory as the
-        project which shall be deployed.
-        Defaults to false and installs all pacakges found via pip freeze if
-        not set.
+    :param str requirements:
+        If set, only the packages in the supplied requirements file are
+        installed.
+        If not set then installs all packages found via pip freeze.
     :param str local_package:
         The path to a local package with should be included in the deploy as
         well (and/or is not available on PyPi)
     """
     packages = []
-    if not use_requirements:
+    if not requirements:
         print('Gathering pip packages')
         packages.extend(pip.operations.freeze.freeze())
     else:
-        if os.path.exists('requirements.txt'):
+        if os.path.exists(requirements):
             print('Gathering requirement packages')
-            data = read('requirements.txt')
+            data = read(requirements)
             packages.extend(data.splitlines())
 
     if not packages:
@@ -680,6 +678,7 @@ def function_exists(cfg):
     except client.exceptions.ResourceNotFoundException as e:
         if 'Function not found' in str(e):
             return False
+
 
 def read_cfg(path_to_config_file, profile_name):
     cfg = read(path_to_config_file, loader=yaml.load)

--- a/scripts/lambda
+++ b/scripts/lambda
@@ -48,10 +48,10 @@ def init(folder, minimal):
     help='AWS profile to use.',
 )
 @click.option(
-    '--use-requirements',
-    default=False,
-    is_flag=True,
-    help='Install all packages defined in requirements.txt',
+    '--requirements',
+    default=None,
+    type=click.Path(),
+    help='Install packages from supplied requirements file.',
 )
 @click.option(
     '--local-package',
@@ -60,10 +60,10 @@ def init(folder, minimal):
     help='Install local package as well.',
     multiple=True,
 )
-def build(use_requirements, local_package, config_file, profile):
+def build(requirements, local_package, config_file, profile):
     aws_lambda.build(
         CURRENT_DIR,
-        use_requirements=use_requirements,
+        requirements=requirements,
         local_package=local_package,
         config_file=config_file,
         profile_name=profile,
@@ -107,10 +107,10 @@ def invoke(event_file, config_file, profile, verbose):
     help='AWS profile to use.',
 )
 @click.option(
-    '--use-requirements',
-    default=False,
-    is_flag=True,
-    help='Install all packages defined in requirements.txt',
+    '--requirements',
+    default=None,
+    type=click.Path(),
+    help='Install all packages defined in supplied requirements file',
 )
 @click.option(
     '--local-package',
@@ -119,10 +119,10 @@ def invoke(event_file, config_file, profile, verbose):
     help='Install local package as well.',
     multiple=True,
 )
-def deploy(use_requirements, local_package, config_file, profile):
+def deploy(requirements, local_package, config_file, profile):
     aws_lambda.deploy(
         CURRENT_DIR,
-        use_requirements=use_requirements,
+        requirements=requirements,
         local_package=local_package,
         config_file=config_file,
         profile_name=profile,
@@ -140,10 +140,10 @@ def deploy(use_requirements, local_package, config_file, profile):
     help='AWS profile to use.',
 )
 @click.option(
-    '--use-requirements',
-    default=False,
-    is_flag=True,
-    help='Install all packages defined in requirements.txt',
+    '--requirements',
+    default=None,
+    type=click.Path(),
+    help='Install all packages defined in supplied requirements file',
 )
 @click.option(
     '--local-package',
@@ -152,10 +152,10 @@ def deploy(use_requirements, local_package, config_file, profile):
     help='Install local package as well.',
     multiple=True,
 )
-def upload(use_requirements, local_package, config_file, profile):
+def upload(requirements, local_package, config_file, profile):
     aws_lambda.upload(
         CURRENT_DIR,
-        use_requirements=use_requirements,
+        requirements=requirements,
         local_package=local_package,
         config_file=config_file,
         profile_name=profile,
@@ -173,10 +173,10 @@ def upload(use_requirements, local_package, config_file, profile):
     help='AWS profile to use.',
 )
 @click.option(
-    '--use-requirements',
-    default=False,
-    is_flag=True,
-    help='Install all packages defined in requirements.txt',
+    '--requirements',
+    default=None,
+    type=click.Path(),
+    help='Install all packages defined in supplied requirements file',
 )
 @click.option(
     '--local-package',
@@ -185,10 +185,10 @@ def upload(use_requirements, local_package, config_file, profile):
     multiple=True,
     help='Install local package as well.',
 )
-def deploy_s3(use_requirements, local_package, config_file, profile):
+def deploy_s3(requirements, local_package, config_file, profile):
     aws_lambda.deploy_s3(
         CURRENT_DIR,
-        use_requirements=use_requirements,
+        requirements=requirements,
         local_package=local_package,
         config_file=config_file,
         profile_name=profile,


### PR DESCRIPTION
Fixes #86 (@karthich)

** Breaks backwards compatibility! **

I changed the `--use-requirements` flag to `--requirements <PATH>` to allow a path to be specified.

If you are concerned about backwards compatibility the existing flag and behavior can be preserved.  I think it might be confusing to have two flags that do roughly the same thing, but I'm not sure how many people are using the current behavior.