### PR TITLE
Set the VPC during lambda creation time (#101)

### DIFF
--- a/aws_lambda/aws_lambda.py
+++ b/aws_lambda/aws_lambda.py
@@ -523,6 +523,10 @@ def create_function(cfg, path_to_zip_file, use_s3=False, s3_file=None):
             'Description': cfg.get('description'),
             'Timeout': cfg.get('timeout', 15),
             'MemorySize': cfg.get('memory_size', 512),
+            'VpcConfig': {
+                'SubnetIds': cfg.get('subnet_ids', []),
+                'SecurityGroupIds': cfg.get('security_group_ids', []),
+            },
             'Publish': True,
         }
     else:
@@ -535,6 +539,10 @@ def create_function(cfg, path_to_zip_file, use_s3=False, s3_file=None):
             'Description': cfg.get('description'),
             'Timeout': cfg.get('timeout', 15),
             'MemorySize': cfg.get('memory_size', 512),
+            'VpcConfig': {
+                'SubnetIds': cfg.get('subnet_ids', []),
+                'SecurityGroupIds': cfg.get('security_group_ids', []),
+            },
             'Publish': True,
         }
 


### PR DESCRIPTION
The VPC settings are applied on updates, but they were missing on creation.  Added them in.  #101 