### PR TITLE
Fixed installation of futures on python3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ boto3==1.4.4
 botocore==1.5.62
 click==6.6
 docutils==0.12
-futures==3.0.5
 jmespath==0.9.0
 pyaml==15.8.2
 python-dateutil==2.5.3

--- a/setup.py
+++ b/setup.py
@@ -13,12 +13,11 @@ requirements = pip.req.parse_requirements(
     'requirements.txt', session=pip.download.PipSession(),
 )
 
+pip_requirements = [str(r.req) for r in requirements]
+
 # Only install futures package if using a Python version <= 2.7
-if sys.version_info[0] == 2:
-    pip_requirements = [str(r.req) for r in requirements]
-else:
-    pip_requirements = [str(r.req)
-                        for r in requirements if 'futures' not in str(r.req)]
+if sys.version_info < (3, 0):
+    pip_requirements.append('futures')
 
 test_requirements = [
     # TODO: put package test requirements here


### PR DESCRIPTION
For some odd reason futures is being installed despite running python3. This is a quick fix tested on both python 3.6.3 and 2.7 to ensure futures is only installed on version 2.

Issue #106 