### PR TITLE
added cli option to preserve VPC settings on update; fixes #78

### DIFF
--- a/aws_lambda/aws_lambda.py
+++ b/aws_lambda/aws_lambda.py
@@ -637,7 +637,11 @@ def update_function(
     }
 
     if preserve_vpc:
-        kwargs['VpcConfig'] = existing_cfg.get('VpcConfig')
+        kwargs['VpcConfig'] = existing_cfg.get('Configuration').get('VpcConfig')
+        if kwargs['VpcConfig'] is None:
+            kwargs['VpcConfig'] = {}
+        else:
+            del kwargs['VpcConfig']['VpcId']
     else:
         kwargs['VpcConfig'] = {
             'SubnetIds': cfg.get('subnet_ids', []),

--- a/aws_lambda/aws_lambda.py
+++ b/aws_lambda/aws_lambda.py
@@ -639,7 +639,10 @@ def update_function(
     if preserve_vpc:
         kwargs['VpcConfig'] = existing_cfg.get('Configuration').get('VpcConfig')
         if kwargs['VpcConfig'] is None:
-            kwargs['VpcConfig'] = {}
+            kwargs['VpcConfig'] = {
+                'SubnetIds': cfg.get('subnet_ids', []),
+                'SecurityGroupIds': cfg.get('security_group_ids', []),
+            }
         else:
             del kwargs['VpcConfig']['VpcId']
     else:

--- a/aws_lambda/aws_lambda.py
+++ b/aws_lambda/aws_lambda.py
@@ -637,7 +637,7 @@ def update_function(
     }
 
     if preserve_vpc:
-        kwargs['VpcConfig'] = existing_cfg.get('Configuration').get('VpcConfig')
+        kwargs['VpcConfig'] = existing_cfg.get('Configuration', {}).get('VpcConfig')
         if kwargs['VpcConfig'] is None:
             kwargs['VpcConfig'] = {
                 'SubnetIds': cfg.get('subnet_ids', []),

--- a/aws_lambda/aws_lambda.py
+++ b/aws_lambda/aws_lambda.py
@@ -112,7 +112,7 @@ def deploy(
 
     existing_config = get_function_config(cfg)
     if existing_config:
-        update_function(cfg, path_to_zip_file, existing_config, preserve_vpc)
+        update_function(cfg, path_to_zip_file, existing_config, preserve_vpc=preserve_vpc)
     else:
         create_function(cfg, path_to_zip_file)
 

--- a/scripts/lambda
+++ b/scripts/lambda
@@ -119,13 +119,20 @@ def invoke(event_file, config_file, profile, verbose):
     help='Install local package as well.',
     multiple=True,
 )
-def deploy(requirements, local_package, config_file, profile):
+@click.option(
+    '--preserve-vpc',
+    default=False,
+    is_flag=True,
+    help='Preserve VPC configuration on existing functions',
+)
+def deploy(requirements, local_package, config_file, profile, preserve_vpc):
     aws_lambda.deploy(
         CURRENT_DIR,
         requirements=requirements,
         local_package=local_package,
         config_file=config_file,
         profile_name=profile,
+        preserve_vpc=preserve_vpc,
     )
 
 


### PR DESCRIPTION
This adds a command line option called `--preserve-vpc` which allows you to omit the VPC settings (i.e. subnets and security groups) so that it will preserve whatever settings are already present on updates. This is useful when deploying the same function to multiple accounts where the security groups and subnets will necessarily change.