### PR TITLE
Add mock for context to test timeout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,5 @@ target/
 
 # vim swap files
 .*.sw?
+aws_lambda/.DS_Store
+.DS_Store

--- a/aws_lambda/aws_lambda.py
+++ b/aws_lambda/aws_lambda.py
@@ -411,13 +411,8 @@ def _install_packages(path, packages):
             package = package.replace('-e ', '')
 
         print('Installing {package}'.format(package=package))
-        pip_major_version = [int(v) for v in pip.__version__.split('.')][0]
-        if pip_major_version >= 10:
-            from pip._internal import main
-            main(['install', package, '-t', path, '--ignore-installed'])
-        else:
-            pip.main(['install', package, '-t', path, '--ignore-installed'])
         subprocess.check_call([sys.executable, '-m', 'pip', 'install', package, '-t', path, '--ignore-installed'])
+    print ('Install directory contents are now: {directory}'.format(directory=os.listdir(path)))
 
 
 def pip_install_to_target(path, requirements=None, local_package=None):

--- a/aws_lambda/aws_lambda.py
+++ b/aws_lambda/aws_lambda.py
@@ -16,8 +16,8 @@ from tempfile import mkdtemp
 
 import boto3
 import botocore
-import pip
 import yaml
+import subprocess
 
 from .helpers import archive
 from .helpers import get_environment_variable_value
@@ -417,6 +417,7 @@ def _install_packages(path, packages):
             main(['install', package, '-t', path, '--ignore-installed'])
         else:
             pip.main(['install', package, '-t', path, '--ignore-installed'])
+        subprocess.check_call([sys.executable, '-m', 'pip', 'install', package, '-t', path, '--ignore-installed'])
 
 
 def pip_install_to_target(path, requirements=None, local_package=None):
@@ -436,12 +437,8 @@ def pip_install_to_target(path, requirements=None, local_package=None):
     packages = []
     if not requirements:
         print('Gathering pip packages')
-        pip_major_version = [int(v) for v in pip.__version__.split('.')][0]
-        if pip_major_version >= 10:
-            from pip._internal import operations
-            packages.extend(operations.freeze.freeze())
-        else:
-            packages.extend(pip.operations.freeze.freeze())
+        pkgStr = subprocess.check_call([sys.executable, '-m', 'pip', 'freeze'])
+        packages.extend(pkgStr.decode('utf-8').splitlines())
     else:
         if os.path.exists(requirements):
             print('Gathering requirement packages')

--- a/aws_lambda/aws_lambda.py
+++ b/aws_lambda/aws_lambda.py
@@ -24,6 +24,7 @@ from .helpers import get_environment_variable_value
 from .helpers import mkdir
 from .helpers import read
 from .helpers import timestamp
+from .helpers import LambdaContext
 
 
 ARN_PREFIXES = {
@@ -226,11 +227,14 @@ def invoke(
     # into a function we can execute.
     fn = get_callable_handler_function(src, handler)
 
-    # TODO: look into mocking the ``context`` variable, currently being passed
-    # as None.
+    timeout = cfg.get('timeout')
+    if timeout:
+        context = LambdaContext(cfg.get('function_name'),timeout)
+    else:
+        context = LambdaContext(cfg.get('function_name'))
 
     start = time.time()
-    results = fn(event, None)
+    results = fn(event, context)
     end = time.time()
 
     print('{0}'.format(results))

--- a/aws_lambda/helpers.py
+++ b/aws_lambda/helpers.py
@@ -3,6 +3,7 @@ import datetime as dt
 import os
 import re
 import zipfile
+import time
 
 
 def mkdir(path):
@@ -41,3 +42,22 @@ def get_environment_variable_value(val):
         if match is not None:
             env_val = os.environ.get(match.group('environment_key_name'))
     return env_val
+
+class LambdaContext:   
+    current_milli_time = lambda x: int(round(time.time() * 1000))
+
+    def get_remaining_time_in_millis(self):
+        return max(0, self.timeout_millis - (self.current_milli_time() - self.start_time_millis))
+
+    def __init__(self,function_name, timeoutSeconds = 3):
+        self.function_name = function_name
+        self.function_version = None
+        self.invoked_function_arn = None
+        self.memory_limit_in_mb = None
+        self.aws_request_id = None
+        self.log_group_name = None
+        self.log_stream_name = None
+        self.identity = None
+        self.client_context = None
+        self.timeout_millis = timeoutSeconds * 1000
+        self.start_time_millis = self.current_milli_time()

--- a/tests/unit/test_LambdaContext.py
+++ b/tests/unit/test_LambdaContext.py
@@ -1,0 +1,14 @@
+from aws_lambda.helpers import LambdaContext
+import time
+import unittest
+
+class TestLambdaContext(unittest.TestCase):
+
+	def test_get_remaining_time_in_millis(self):
+		context = LambdaContext('function_name',2000)
+		time.sleep(.5)
+		self.assertTrue(context.get_remaining_time_in_millis() < 2000)
+
+
+if __name__ == '__main__':
+	unittest.main()


### PR DESCRIPTION
My Lambda function relies on the context object's ability to report the remaining time so that it can perform recovery operations before timeout. 

I created a context mock objects with all the properties that are given in the documentation [https://docs.aws.amazon.com/lambda/latest/dg/python-context-object.html]. Most of these are set to None, but can be built upon later. The get_remaining_time_in_millis function is defined, and uses the instantiation time of the context object as the start of its timer, and the value provided in the config to set the timeout (default timeout is 3 seconds, as per Lambda specs).

This does not address the problem of actually stopping the execution of the Lambda after the specified timeout. The context will just return 0 if too much time has passed.