### PR TITLE
combined changes from simon-weber and kmbenitez; will fix #126

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,5 @@ target/
 
 # vim swap files
 .*.sw?
+aws_lambda/.DS_Store
+.DS_Store

--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,7 @@ With python-lambda and `pytube <https://github.com/nficano/pytube/>`_ both conti
 Description
 ===========
 
-AWS Lambda is a service that allows you to write Python, Java, Node.js, C# or Go code that gets executed in response to events like http requests or files uploaded to S3.
+AWS Lambda is a service that allows you to write Python, Java, or Node.js code that gets executed in response to events like http requests or files uploaded to S3.
 
 Working with Lambda is relatively easy, but the process of bundling and deploying your code is not as simple as it could be.
 

--- a/aws_lambda/__init__.py
+++ b/aws_lambda/__init__.py
@@ -2,7 +2,7 @@
 # flake8: noqa
 __author__ = 'Nick Ficano'
 __email__ = 'nficano@gmail.com'
-__version__ = '3.2.3'
+__version__ = '3.2.5'
 
 from .aws_lambda import deploy, deploy_s3, invoke, init, build, upload, cleanup_old_versions
 

--- a/aws_lambda/helpers.py
+++ b/aws_lambda/helpers.py
@@ -2,6 +2,7 @@
 import datetime as dt
 import os
 import re
+import time
 import zipfile
 
 
@@ -41,3 +42,22 @@ def get_environment_variable_value(val):
         if match is not None:
             env_val = os.environ.get(match.group('environment_key_name'))
     return env_val
+
+class LambdaContext:   
+    current_milli_time = lambda x: int(round(time.time() * 1000))
+
+    def get_remaining_time_in_millis(self):
+        return max(0, self.timeout_millis - (self.current_milli_time() - self.start_time_millis))
+
+    def __init__(self,function_name, timeoutSeconds = 3):
+        self.function_name = function_name
+        self.function_version = None
+        self.invoked_function_arn = None
+        self.memory_limit_in_mb = None
+        self.aws_request_id = None
+        self.log_group_name = None
+        self.log_stream_name = None
+        self.identity = None
+        self.client_context = None
+        self.timeout_millis = timeoutSeconds * 1000
+        self.start_time_millis = self.current_milli_time()

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [bumpversion]
 commit = True
 tag = True
-current_version = 3.2.3
+current_version = 3.2.5
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+))?
 serialize = 
 	{major}.{minor}.{patch}

--- a/setup.py
+++ b/setup.py
@@ -2,31 +2,21 @@
 # -*- coding: utf-8 -*-
 import sys
 
-try: # for pip >= 10
-    from pip._internal.req import parse_requirements
-except ImportError: # for pip <= 9.0.3
-    from pip.req import parse_requirements
-
-try: # for pip >= 10
-    from pip._internal import download
-except ImportError: # for pip <= 9.0.3
-    from pip import download
-
 from setuptools import find_packages
 from setuptools import setup
 
 with open('README.rst') as readme_file:
     readme = readme_file.read()
 
-requirements = parse_requirements(
-    'requirements.txt', session=download.PipSession(),
-)
-
-pip_requirements = [str(r.req) for r in requirements]
+requirements = [
+    'boto3',
+    'click',
+    'PyYAML',
+]
 
 # Only install futures package if using a Python version <= 2.7
 if sys.version_info < (3, 0):
-    pip_requirements.append('futures')
+    requirements.append('futures')
 
 test_requirements = [
     # TODO: put package test requirements here
@@ -34,7 +24,7 @@ test_requirements = [
 
 setup(
     name='python-lambda',
-    version='3.2.3',
+    version='3.2.5',
     description='The bare minimum for a Python app running on Amazon Lambda.',
     long_description=readme,
     author='Nick Ficano',
@@ -47,7 +37,7 @@ setup(
     },
     include_package_data=True,
     scripts=['scripts/lambda'],
-    install_requires=pip_requirements,
+    install_requires=requirements,
     license='ISCL',
     zip_safe=False,
     keywords='python-lambda',

--- a/tests/unit/test_LambdaContext.py
+++ b/tests/unit/test_LambdaContext.py
@@ -1,0 +1,14 @@
+from aws_lambda.helpers import LambdaContext
+import time
+import unittest
+
+class TestLambdaContext(unittest.TestCase):
+
+	def test_get_remaining_time_in_millis(self):
+		context = LambdaContext('function_name',2000)
+		time.sleep(.5)
+		self.assertTrue(context.get_remaining_time_in_millis() < 2000)
+
+
+if __name__ == '__main__':
+	unittest.main()


### PR DESCRIPTION
I could have done this differently but this was easiest for me as I already had my own fork. I took the changes from @simon-weber to abstractly declare install_requires (which was in its own separate PR) and the changes from @kmbenitez to use subprocess instead of pip internals (which was not in a PR). The first is a harmless change that was being asked for; the second is a necessary change to fix a bug that prevents more than one package from being deployed (which has existed since 3.2.2 - ever since pip changed its internals, apparently).