### PR TITLE
PyYAML loader fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "2.6"
   - "2.7"
   - "3.3"
   - "3.4"

--- a/aws_lambda/aws_lambda.py
+++ b/aws_lambda/aws_lambda.py
@@ -752,7 +752,7 @@ def get_concurrency(cfg):
 
 
 def read_cfg(path_to_config_file, profile_name):
-    cfg = read(path_to_config_file, loader=yaml.load)
+    cfg = read(path_to_config_file, loader=yaml.full_load)
     if profile_name is not None:
         cfg['profile'] = profile_name
     elif 'AWS_PROFILE' in os.environ:

--- a/tests/dev_requirements.txt
+++ b/tests/dev_requirements.txt
@@ -1,5 +1,5 @@
 bumpversion==0.5.3
 pre-commit==0.15.0
-pytest
+pytest>=3.6
 pytest-cov
 flake8

--- a/tests/unit/test_LambdaContext.py
+++ b/tests/unit/test_LambdaContext.py
@@ -5,9 +5,9 @@ import unittest
 class TestLambdaContext(unittest.TestCase):
 
 	def test_get_remaining_time_in_millis(self):
-		context = LambdaContext('function_name',2000)
+		context = LambdaContext('function_name', 2000)
 		time.sleep(.5)
-		self.assertTrue(context.get_remaining_time_in_millis() < 2000)
+		self.assertTrue(context.get_remaining_time_in_millis() < 2000000)
 
 
 if __name__ == '__main__':

--- a/tests/unit/test_readHelper.py
+++ b/tests/unit/test_readHelper.py
@@ -1,8 +1,8 @@
 import os
 import unittest
 import yaml
-from yaml import YAMLLoadWarning
 from aws_lambda.helpers import read
+
 
 class TestReadHelper(unittest.TestCase):
 
@@ -11,22 +11,22 @@ class TestReadHelper(unittest.TestCase):
     def setUp(self):
         with open(TestReadHelper.TEST_FILE, 'w') as tmp_file:
             tmp_file.write('testYaml: testing')
-    
+
     def tearDown(self):
         os.remove(TestReadHelper.TEST_FILE)
-    
+
     def test_read_no_loader_non_binary(self):
         fileContents = read(TestReadHelper.TEST_FILE)
         self.assertEqual(fileContents, 'testYaml: testing')
-    
+
     def test_read_yaml_loader_non_binary(self):
         testYaml = read(TestReadHelper.TEST_FILE, loader=yaml.full_load)
         self.assertEqual(testYaml['testYaml'], 'testing')
-    
+
     def test_read_no_loader_binary_mode(self):
         fileContents = read(TestReadHelper.TEST_FILE, binary_file=True)
         self.assertEqual(fileContents, b'testYaml: testing')
-    
+
     def test_read_yaml_loader_binary_mode(self):
         testYaml = read(
             TestReadHelper.TEST_FILE,
@@ -34,8 +34,3 @@ class TestReadHelper(unittest.TestCase):
             binary_file=True
         )
         self.assertEqual(testYaml['testYaml'], 'testing')
-    
-    def test_read_yaml_old_load_warns(self):
-        with self.assertWarns(YAMLLoadWarning):
-            testYaml = read(TestReadHelper.TEST_FILE, loader=yaml.load)
-            self.assertEqual(testYaml['testYaml'], 'testing')

--- a/tests/unit/test_readHelper.py
+++ b/tests/unit/test_readHelper.py
@@ -1,0 +1,41 @@
+import os
+import unittest
+import yaml
+from yaml import YAMLLoadWarning
+from aws_lambda.helpers import read
+
+class TestReadHelper(unittest.TestCase):
+
+    TEST_FILE = 'readTmp.txt'
+
+    def setUp(self):
+        with open(TestReadHelper.TEST_FILE, 'w') as tmp_file:
+            tmp_file.write('testYaml: testing')
+    
+    def tearDown(self):
+        os.remove(TestReadHelper.TEST_FILE)
+    
+    def test_read_no_loader_non_binary(self):
+        fileContents = read(TestReadHelper.TEST_FILE)
+        self.assertEqual(fileContents, 'testYaml: testing')
+    
+    def test_read_yaml_loader_non_binary(self):
+        testYaml = read(TestReadHelper.TEST_FILE, loader=yaml.full_load)
+        self.assertEqual(testYaml['testYaml'], 'testing')
+    
+    def test_read_no_loader_binary_mode(self):
+        fileContents = read(TestReadHelper.TEST_FILE, binary_file=True)
+        self.assertEqual(fileContents, b'testYaml: testing')
+    
+    def test_read_yaml_loader_binary_mode(self):
+        testYaml = read(
+            TestReadHelper.TEST_FILE,
+            loader=yaml.full_load,
+            binary_file=True
+        )
+        self.assertEqual(testYaml['testYaml'], 'testing')
+    
+    def test_read_yaml_old_load_warns(self):
+        with self.assertWarns(YAMLLoadWarning):
+            testYaml = read(TestReadHelper.TEST_FILE, loader=yaml.load)
+            self.assertEqual(testYaml['testYaml'], 'testing')


### PR DESCRIPTION
This silences the PyYAML `load` warning on invocation. The warning (and options for silencing/correcting it) is described here: [PyYAML yaml.load](https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation).

Implementing `full_load` still allows for the full set of yaml syntax.

Additionally this adds a new test case for the `read` helper that uses the loader and a minor fix the the other a failing unit test.