### PR TITLE
Remove python3.3 from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python:
   - "2.7"
-  - "3.3"
   - "3.4"
   - "3.5"
   - "3.6"


### PR DESCRIPTION
AWS only supports python 3.6 and 3.7.
Also, python 3.3 reached the end of its life on 29 September 2017.