### PR TITLE
Testing out a change with Travis config to stop Python3.6 CI failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
   - "3.7"
   - "3.8"
 before_install:
+  - pip install --upgrade pip
   - pip install pipenv --upgrade
 script:
   - pipenv install --dev


### PR DESCRIPTION
With CI failures such as the ones in #531, my suspicion is that it is due to older pip versions on Travis systems. Planning to upgrade `pip` before installing other packages. 